### PR TITLE
Jch

### DIFF
--- a/breviarium/psalmi.json
+++ b/breviarium/psalmi.json
@@ -38,11 +38,34 @@
 	]},
 	{"tags":["psalmus-iv"],
 	"datum":[
-		"PASTA"
+		"Cum invocárem exaudívit me Deus justítiæ meæ: * in tribulatióne dilatásti mihi.",
+		"Miserére mei, * et exaúdi oratiónem meam.",
+		"Fílii hóminum úsquequo gravi corde? * ut quid dilígitis vanitátem, et quǽritis mendácium?",
+		"Et scitóte quóniam mirificávit Dóminus sanctum suum: * Dóminus exaúdiet me cum clamávero ad eum.",
+		"Irascímini, et nolíte peccáre: + quæ dícitis in córdibus vestris, * in cubílibus vestris compungímini.",
+		"Sacrificáte sacrifícium justítiæ, + et speráte in Dómino. * Multi dicunt: Quis osténdit nobis bona?",
+		"Signátum est super nos lumen vultus tui Dómine: * dedísti lætítiam in corde meo.",
+		"A fructu fruménti, vini, et ólei sui * multiplicáti sunt.",
+		"In pace in idípsum * dórmiam, et requiéscam;",
+		"Quóniam tu Dómine singuláriter in spe * constituísti me."
 	]},
 	{"tags":["psalmus-v"],
 	"datum":[
-		"PASTA"
+		"Verba mea aúribus pércipe Dómine, * intéllige clamórem meum.",
+		"Inténde voci oratiónis meæ, * rex meus et Deus meus.",
+		"Quóniam ad te orábo: * Dómine mane exaúdies vocem meam.",
+		"Mane astábo tibi et vidébo: * quóniam non Deus volens iniquitátem tu es.",
+		"Neque habitábit juxta te malígnus: * neque permanébunt injústi ante óculos tuos.",
+		"Odísti omnes, qui operántur iniquitátem: * perdes omnes, qui loquúntur mendácium.",
+		"Virum sánguinum et dolósum abominábitur Dóminus: * ego autem in multitúdine misericórdiæ tuæ.",
+		"Introíbo in domum tuam: * adorábo ad templum sanctum tuum in timóre tuo.",
+		"Dómine deduc me in justítia tua: * propter inimícos meos dírige in conspéctu tuo viam meam.",
+		"Quóniam non est in ore eórum véritas: * cor eórum vanum est.",
+		"Sepúlchrum patens est guttur eórum, + linguis suis dolóse agébant, * júdica illos Deus.",
+		"Décidant a cogitatiónibus suis, + secúndum multitúdinem impietátum eórum expélle eos, * quóniam irritavérunt te Dómine.",
+		"Et læténtur omnes, qui sperant in te, * in ætérnum exsultábunt: et habitábis in eis.",
+		"Et gloriabúntur in te omnes, qui díligunt nomen tuum, * quóniam tu benedíces justo.",
+		"Dómine, ut scuto bonæ voluntátis tuæ * coronásti nos."
 	]},
 	{"tags":["psalmus-vi"],
 	"datum":[
@@ -504,7 +527,37 @@
 	]},
 	{"tags":["psalmus-xxx"],
 	"datum":[
-		"PASTA"
+		"In te Dómine sperávi, non confúndar in ætérnum: * in justítia tua líbera me.",
+		"Inclína ad me aurem tuam, * accélera ut éruas me.",
+		"Esto mihi in Deum protectórem: et in domum refúgii, * ut salvum me fácias.",
+		"Quóniam fortitúdo mea, et refúgium meum es tu: * et propter nomen tuum dedúces me, et enútries me.",
+		"Edúces me de láqueo hoc, quem abscondérunt mihi: * quóniam tu es protéctor meus.",
+		"In manus tuas comméndo spíritum meum: * redemísti me Dómine Deus veritátis.",
+		"Odísti observántes vanitátes, * supervácue.",
+		"Ego autem in Dómino sperávi: * exsultábo, et lætábor in misericórdia tua.",
+		"Quóniam respexísti humilitátem meam, * salvásti de necessitátibus ánimam meam.",
+		"Nec conclusísti me in mánibus inimíci: * statuísti in loco spatióso pedes meos.",
+		"Miserére mei Dómine quóniam tríbulor: † conturbátus est in ira óculus meus, ánima mea, et venter meus:",
+		"Quóniam defécit in dolóre vita mea: * et anni mei in gemítibus.",
+		"Infirmáta est in paupertáte virtus mea: * et ossa mea conturbáta sunt.",
+		"Super omnes inimícos meos factus sum oppróbrium et vicínis meis valde: * et timor notis meis.",
+		"Qui vidébant me, foras fugérunt a me: * oblivióni datus sum, tamquam mórtuus a corde.",
+		"Factus sum tamquam vas pérditum: * quóniam audívi vituperatiónem multórum commorántium in circúitu.",
+		"In eo dum convenírent simul advérsum me, * accípere ánimam meam consiliáti sunt.",
+		"Ego autem in te sperávi Dómine: † dixi: Deus meus es tu: in mánibus tuis sortes meæ.",
+		"Eripe me de manu inimicórum meórum, * et a persequéntibus me.",
+		"Illústra fáciem tuam super servum tuum, † salvum me fac in misericórdia tua: * Dómine non confúndar, quóniam invocávi te.",
+		"Erubéscant ímpii, et deducántur in inférnum: * muta fiant lábia dolósa.",
+		"Quæ loquúntur advérsus justum iniquitátem, * in supérbia, et in abusióne.",
+		"Quam magna multitúdo dulcédinis tuæ Dómine, * quam abscondísti timéntibus te.",
+		"Perfecísti eis, qui sperant in te, * in conspéctu filiórum hóminum.",
+		"Abscóndes eos in abscóndito faciéi tuæ * a conturbatióne hóminum.",
+		"Próteges eos in tabernáculo tuo * a contradictióne linguárum.",
+		"Benedíctus Dóminus: * quóniam mirificávit misericórdiam suam mihi in civitáte muníta.",
+		"Ego autem dixi in excéssu mentis meæ: * Projéctus sum a fácie oculórum tuórum.",
+		"Ideo exaudísti vocem oratiónis meæ, * dum clamárem ad te.",
+		"Dilígite Dóminum omnes sancti ejus: † quóniam veritátem requíret Dóminus, et retríbuet abundánter faciéntibus supérbiam.",
+		"Viríliter ágite, et confortétur cor vestrum, * omnes qui sperátis in Dómino."
 	]},
 	{"tags":["psalmus-xxxi"],
 	"datum":[
@@ -781,7 +834,12 @@
 	]},
 	{"tags":["psalmus-xlii"],
 	"datum":[
-		"PASTA"
+		"Júdica me Deus, et discérne causam meam de gente non sancta, * ab hómine iníquo, et dolóso érue me.",
+		"Quia tu es Deus fortitúdo mea: + Quare me repulísti? * et quare tristis incédo, dum afflígit me inimícus?",
+		"Emítte lucem tuam et veritátem tuam: + ipsa me deduxérunt, et adduxérunt in montem sanctum tuum, * et in tabernácula tua.",
+		"Et introíbo ad altáre Dei: * ad Deum, qui lætíficat juventútem meam.",
+		"Confitébor tibi in cíthara Deus Deus meus: * quare tristis es ánima mea? et quare contúrbas me?",
+		"Spera in Deo, quóniam adhuc confitébor illi: * salutáre vultus mei, et Deus meus."
 	]},
 	{"tags":["psalmus-xliii"],
 	"datum":[
@@ -932,7 +990,26 @@
 	]},
 	{"tags":["psalmus-l"],
 	"datum":[
-		"PASTA"
+		"Miserére mei Deus, * secúndum magnam misericórdiam tuam.",
+		"Et secúndum multitúdinem miseratiónum tuárum, * dele iniquitátem meam.",
+		"Ámplius lava me ab iniquitáte mea: * et a peccáto meo munda me.",
+		"Quóniam iniquitátem meam ego cognósco: * et peccátum meum contra me est semper.",
+		"Tibi soli peccávi, et malum coram te feci: * ut justificéris in sermónibus tuis, et vincas cum judicáris.",
+		"Ecce enim in iniquitátibus concéptus sum: * et in peccátis concépit me mater mea.",
+		"Ecce enim veritátem dilexísti: * incérta et occúlta sapiéntiæ tuæ manifestásti mihi.",
+		"Aspérges me hyssópo, et mundábor: * lavábis me, et super nivem dealbábor.",
+		"Audítui meo dabis gaúdium et lætítiam: * et exsultábunt ossa humiliáta.",
+		"Avérte fáciem tuam a peccátis meis: * et omnes iniquitátes meas dele.",
+		"Cor mundum crea in me Deus: * et spíritum rectum ínnova in viscéribus meis.",
+		"Ne projícias me a fácie tua: * et Spíritum sanctum tuum ne aúferas a me.",
+		"Redde mihi lætítiam salutáris tui: * et spíritu principáli confírma me.",
+		"Docébo iníquos vias tuas: * et ímpii ad te converténtur.",
+		"Líbera me de sanguínibus Deus, Deus salútis meæ: * et exsultábit lingua mea justítiam tuam.",
+		"Dómine, lábia mea apéries: * et os meum annuntiábit laudem tuam.",
+		"Quóniam si voluísses sacrifícium, dedíssem útique: * holocaústis non delectáberis.",
+		"Sacrifícium Deo spíritus contribulátus: * cor contrítum, et humiliátum Deus non despícies.",
+		"Benígne fac Dómine in bona voluntáte tua Sion: * ut ædificéntur muri Jerúsalem.",
+		"Tunc acceptábis sacrifícium justítiæ, oblatiónes, et holocaústa: * tunc impónent super altáre tuum vítulos."
 	]},
 	{"tags":["psalmus-li"],
 	"datum":[
@@ -959,7 +1036,13 @@
 	]},
 	{"tags":["psalmus-liii"],
 	"datum":[
-		"PASTA"
+		"Deus in nómine tuo salvum me fac: * et in virtúte tua júdica me.",
+		"Deus exaúdi oratiónem meam: * aúribus pércipe verba oris mei.",
+		"Quóniam aliéni insurrexérunt advérsum me, + et fortes quæsiérunt ánimam meam: * et non proposuérunt Deum ante conspéctum suum.",
+		"Ecce enim Deus ádjuvat me: * et Dóminus suscéptor est ánimæ meæ.",
+		"Avérte mala inimícis meis: * et in veritáte tua dispérde illos.",
+		"Voluntárie sacrificábo tibi, * et confitébor nómini tuo Dómine: quóniam bonum est:",
+		"Quóniam ex omni tribulatióne eripuísti me: * et super inimícos meos despéxit óculus meus."
 	]},
 	{"tags":["psalmus-liv"],
 	"datum":[
@@ -1104,7 +1187,16 @@
 	]},
 	{"tags":["psalmus-lxii"],
 	"datum":[
-		"PASTA"
+		"Deus Deus meus * ad te de luce vígilo.",
+		"Sitívit in te ánima mea, * quam multiplíciter tibi caro mea.",
+		"In terra desérta, et ínvia, et inaquósa: + sic in sancto appárui tibi, * ut vidérem virtútem tuam, et glóriam tuam.",
+		"Quóniam mélior est misericórdia tua super vitas: * lábia mea laudábunt te.",
+		"Sic benedícam te in vita mea: * et in nómine tuo levábo manus meas.",
+		"Sicut ádipe et pinguédine repleátur ánima mea: * et lábiis exsultatiónis laudábit os meum.",
+		"Si memor fui tui super stratum meum, + in matutínis meditábor in te: * quia fuísti adjútor meus.",
+		"Et in velaménto alárum tuárum exsultábo, adhǽsit ánima mea post te: * me suscépit déxtera tua.",
+		"Ipsi vero in vanum quæsiérunt ánimam meam, + introíbunt in inferióra terræ: * tradéntur in manus gládii, partes vúlpium erunt.",
+		"Rex vero lætábitur in Deo, + laudabúntur omnes qui jurant in eo: * quia obstrúctum est os loquéntium iníqua."
 	]},
 	{"tags":["psalmus-lxiii"],
 	"datum":[
@@ -1161,7 +1253,12 @@
 	]},
 	{"tags":["psalmus-lxvi"],
 	"datum":[
-		"PASTA"
+		"Deus misereátur nostri, et benedícat nobis: * illúminet vultum suum super nos, et misereátur nostri.",
+		"Ut cognoscámus in terra viam tuam: * in ómnibus Géntibus salutáre tuum.",
+		"Confiteántur tibi pópuli Deus: * confiteántur tibi pópuli omnes.",
+		"Læténtur et exsúltent Gentes: + quóniam júdicas pópulos in æquitáte, * et Gentes in terra dírigis.",
+		"Confiteántur tibi pópuli Deus, + confiteántur tibi pópuli omnes: * terra dedit fructum suum.",
+		"Benedícat nos Deus, Deus noster, benedícat nos Deus: * et métuant eum omnes fines terræ."
 	]},
 	{"tags":["psalmus-lxvii"],
 	"datum":[
@@ -1753,7 +1850,22 @@
 	]},
 	{"tags":["psalmus-xc"],
 	"datum":[
-		"PASTA"
+		"Qui hábitat in adjutório Altíssimi, * in protectióne Dei cœli commorábitur.",
+		"Dicet Dómino: Suscéptor meus es tu, et refúgium meum: * Deus meus sperábo in eum.",
+		"Quóniam ipse liberávit me de láqueo venántium, * et a verbo áspero.",
+		"Scápulis suis obumbrábit tibi: * et sub pennis ejus sperábis.",
+		"Scuto circúmdabit te véritas ejus: * non timébis a timóre noctúrno,",
+		"A sagítta volánte in die, + a negótio perambulánte in ténebris: * ab incúrsu, et dæmónio meridiáno.",
+		"Cadent a látere tuo mille, + et decem míllia a dextris tuis: * ad te autem non appropinquábit.",
+		"Verúmtamen óculis tuis considerábis: * et retributiónem peccatórum vidébis.",
+		"Quóniam tu es Dómine spes mea: * Altíssimum posuísti refúgium tuum.",
+		"Non accédet ad te malum: * et flagéllum non appropinquábit tabernáculo tuo.",
+		"Quóniam Ángelis suis mandávit de te: * ut custódiant te in ómnibus viis tuis.",
+		"In mánibus portábunt te: * ne forte offéndas ad lápidem pedem tuum.",
+		"Super áspidem, et basilíscum ambulábis: * et conculcábis leónem et dracónem.",
+		"Quóniam in me sperávit, liberábo eum: * prótegam eum, quóniam cognóvit nomen meum.",
+		"Clamábit ad me, et ego exaúdiam eum: + cum ipso sum in tribulatióne: * erípiam eum et glorificábo eum.",
+		"Longitúdine diérum replébo eum: * et osténdam illi salutáre meum."
 	]},
 	{"tags":["psalmus-xci"],
 	"datum":[
@@ -1775,7 +1887,13 @@
 	]},
 	{"tags":["psalmus-xcii"],
 	"datum":[
-		"PASTA"
+		"Dóminus regnávit, decórem indútus est: * indútus est Dóminus fortitúdinem, et præcínxit se.",
+		"Étenim firmávit orbem terræ, * qui non commovébitur.",
+		"Paráta sedes tua ex tunc: * a sǽculo tu es.",
+		"Elevavérunt flúmina Dómine: * elevavérunt flúmina vocem suam.",
+		"Elevavérunt flúmina fluctus suos, * a vócibus aquárum multárum.",
+		"Mirábiles elatiónes maris: * mirábilis in altis Dóminus.",
+		"Testimónia tua credibília facta sunt nimis: * domum tuam decet sanctitúdo Dómine in longitúdinem diérum."
 	]},
 	{"tags":["psalmus-xciii"],
 	"datum":[
@@ -1877,7 +1995,11 @@
 	]},
 	{"tags":["psalmus-xcix"],
 	"datum":[
-		"PASTA"
+		"Jubiláte Deo omnis terra: * servíte Dómino in lætítia.",
+		"Introíte in conspéctu ejus, * in exsultatióne.",
+		"Scitóte quóniam Dóminus ipse est Deus: * ipse fecit nos, et non ipsi nos.",
+		"Pópulus ejus, et oves páscuæ ejus: + introíte portas ejus in confessióne, * átria ejus in hymnis: confitémini illi.",
+		"Laudáte nomen ejus: quóniam suávis est Dóminus, + in ætérnum misericórdia ejus, * et usque in generatiónem et generatiónem véritas ejus."
 	]},
 	{"tags":["psalmus-c"],
 	"datum":[
@@ -2181,22 +2303,61 @@
 		"Confitébor Dómino nimis in ore meo: * et in médio multórum laudábo eum.",
 		"Quia ástitit a dextris páuperis, * ut salvam fáceret a persequéntibus ánimam meam."
 	]},
-	{"tags":["psalmus-cix"],
-	"datum":[
-		"PASTA"
-	]},
-	{"tags":["psalmus-cx"],
-	"datum":[
-		"PASTA"
-	]},
-	{"tags":["psalmus-cxi"],
-	"datum":[
-		"PASTA"
-	]},
-	{"tags":["psalmus-cxii"],
-	"datum":[
-		"PASTA"
-	]},
+	{
+		"tags":["psalmus-cix"],
+		"datum":[
+			"Dixit Dóminus Dómino meo: * Sede a dextris meis:",
+			"Donec ponam inimícos tuos, * scabéllum pedum tuórum.",
+			"Virgam virtútis tuæ emíttet Dóminus ex Sion: * domináre in médio inimicórum tuórum.",
+			"Tecum princípium in die virtútis tuæ in splendóribus sanctórum: * ex útero ante lucíferum génui te.",
+			"Jurávit Dóminus, et non pœnitébit eum: * Tu es sacérdos in ætérnum secúndum órdinem Melchísedech.",
+			"Dóminus a dextris tuis, * confrégit in die iræ suæ reges.",
+			"Judicábit in natiónibus, implébit ruínas: * conquassábit cápita in terra multórum.",
+			"De torrénte in via bibet: * proptérea exaltábit caput."
+		]
+	},
+	{
+		"tags":["psalmus-cx"],
+		"datum":[
+			"Confitébor tibi Dómine in toto corde meo: * in consílio justórum, et congregatióne.",
+			"Magna ópera Dómini: * exquisíta in omnes voluntátes ejus.",
+			"Conféssio et magnificéntia opus ejus: * et justítia ejus manet in sǽculum sǽculi.",
+			"Memóriam fecit mirabílium suórum, + miséricors et miserátor Dóminus: * escam dedit timéntibus se.",
+			"Memor erit in sǽculum testaménti sui: * virtútem óperum suórum annuntiábit pópulo suo:",
+			"Ut det illis hæreditátem Géntium: * ópera mánuum ejus véritas, et judícium.",
+			"Fidélia ómnia mandáta ejus: + confirmáta in sǽculum sǽculi, * facta in veritáte et æquitáte.",
+			"Redemptiónem misit pópulo suo: * mandávit in ætérnum testaméntum suum.",
+			"Sanctum, et terríbile nomen ejus: * inítium sapiéntiæ timor Dómini.",
+			"Intelléctus bonus ómnibus faciéntibus eum: * laudátio ejus manet in sǽculum sǽculi."
+		]
+	},
+	{
+		"tags":["psalmus-cxi"],
+		"datum":[
+			"Beátus vir, qui timet Dóminum: * in mandátis ejus volet nimis.",
+			"Potens in terra erit semen ejus: * generátio rectórum benedicétur.",
+			"Glória, et divítiæ in domo ejus: * et justítia ejus manet in sǽculum sǽculi.",
+			"Exórtum est in ténebris lumen rectis: * miséricors, et miserátor, et justus.",
+			"Jucúndus homo qui miserétur et cómmodat, + dispónet sermónes suos in judício: * quia in ætérnum non commovébitur.",
+			"In memória ætérna erit justus: * ab auditióne mala non timébit.",
+			"Parátum cor ejus speráre in Dómino, + confirmátum est cor ejus: * non commovébitur donec despíciat inimícos suos.",
+			"Dispérsit, dedit paupéribus: + justítia ejus manet in sǽculum sǽculi, * cornu ejus exaltábitur in glória.",
+			"Peccátor vidébit, et irascétur, + déntibus suis fremet et tabéscet: * desidérium peccatórum períbit."
+		]
+	},
+	{
+		"tags":["psalmus-cxii"],
+		"datum":[
+			"Laúdate púeri Dóminum: * laudáte nomen Dómini.",
+			"Sit nomen Dómini benedíctum, * ex hoc nunc, et usque in sǽculum.",
+			"A solis ortu usque ad occásum, * laudábile nomen Dómini.",
+			"Excélsus super omnes Gentes Dóminus, * et super cœlos glória ejus.",
+			"Quis sicut Dóminus Deus noster, qui in altis hábitat, * et humília réspicit in cœlo et in terra?",
+			"Súscitans a terra ínopem, * et de stércore érigens paúperem:",
+			"Ut cóllocet eum cum princípibus, * cum princípibus pópuli sui.",
+			"Qui habitáre facit stérilem in domo, * matrem filiórum lætántem."
+		]
+	},
 	{"tags":["psalmus-cxiii"],
 	"datum":[
 		"In éxitu Israël de Ægýpto, * domus Jacob de pópulo bárbaro:",
@@ -2287,13 +2448,306 @@
 		"Confitébor tibi quóniam exaudísti me: * et factus es mihi in salútem.",
 		"Confitémini Dómino quóniam bonus: * quóniam in sǽculum misericórdia ejus."
 	]},
-	{"tags":["psalmus-cxviii"],
-	"datum":[
-		"PASTA"
-	]},
+	{
+		"tags":["psalmus-cxviii-i"],
+		"datum":[
+			"Beáti immaculáti in via: * qui ámbulant in lege Dómini.",
+			"Beáti, qui scrutántur testimónia ejus: * in toto corde exquírunt eum.",
+			"Non enim qui operántur iniquitátem, * in viis ejus ambulavérunt.",
+			"Tu mandásti * mandáta tua custodíri nimis.",
+			"Útinam dirigántur viæ meæ, * ad custodiéndas justificatiónes tuas!",
+			"Tunc non confúndar, * cum perspéxero in ómnibus mandátis tuis.",
+			"Confitébor tibi in directióne cordis: * in eo quod dídici judícia justítiæ tuæ.",
+			"Justificatiónes tuas custódiam: * non me derelínquas usquequáque."
+		]
+	},
+	{
+		"tags":["psalmus-cxviii-ii"],
+		"datum":[
+			"In quo córrigit adolescéntior viam suam? * in custodiéndo sermónes tuos.",
+			"In toto corde meo exquisívi te: * ne repéllas me a mandátis tuis.",
+			"In corde abscóndi elóquia tua: * ut non peccem tibi.",
+			"Benedíctus es Dómine: * doce me justificatiónes tuas.",
+			"In lábiis meis, * pronuntiávi ómnia judícia oris tui.",
+			"In via testimoniórum tuórum delectátus sum, * sicut in ómnibus divítiis.",
+			"In mandátis tuis exercébor: * et considerábo vias tuas.",
+			"In justificatiónibus tuis meditábor: * non oblivíscar sermónes tuos."
+		]
+	},
+	{
+		"tags":["psalmus-cxviii-iii"],
+		"datum":[
+			"Retríbue servo tuo, vivífica me: * et custódiam sermónes tuos.",
+			"Revéla óculos meos: * et considerábo mirabília de lege tua.",
+			"Íncola ego sum in terra: * non abscóndas a me mandáta tua.",
+			"Concupívit ánima mea desideráre justificatiónes tuas, * in omni témpore.",
+			"Increpásti supérbos: * maledícti qui declínant a mandátis tuis.",
+			"Aufer a me oppróbrium, et contémptum: * quia testimónia tua exquisívi.",
+			"Étenim sedérunt príncipes, et advérsum me loquebántur: * servus autem tuus exercebátur in justificatiónibus tuis.",
+			"Nam et testimónia tua meditátio mea est: * et consílium meum justificatiónes tuæ."
+		]
+	},
+	{
+		"tags":["psalmus-cxviii-iv"],
+		"datum":[
+			"Adhǽsit paviménto ánima mea: * vivífica me secúndum verbum tuum.",
+			"Vias meas enuntiávi, et exaudísti me: * doce me justificatiónes tuas.",
+			"Viam justificatiónum tuárum ínstrue me: * et exercébor in mirabílibus tuis.",
+			"Dormitávit ánima mea præ tǽdio: * confírma me in verbis tuis.",
+			"Viam iniquitátis ámove a me: * et de lege tua miserére mei.",
+			"Viam veritátis elégi: * judícia tua non sum oblítus.",
+			"Adhǽsi testimóniis tuis, Dómine: * noli me confúndere.",
+			"Viam mandatórum tuórum cucúrri, * cum dilatásti cor meum."
+		]
+	},
+	{
+		"tags":["psalmus-cxviii-v"],
+		"datum":[
+			"Legem pone mihi Dómine viam justificatiónum tuárum: * et exquíram eam semper.",
+			"Da mihi intelléctum, et scrutábor legem tuam: * et custódiam illam in toto corde meo.",
+			"Deduc me in sémitam mandatórum tuórum: * quia ipsam vólui.",
+			"Inclína cor meum in testimónia tua: * et non in avarítiam.",
+			"Avérte óculos meos ne vídeant vanitátem: * in via tua vivífica me.",
+	"Státue servo tuo elóquium tuum, * in timóre tuo.",
+			"Ámputa oppróbrium meum quod suspicátus sum: * quia judícia tua jucúnda.",
+	"Ecce concupívi mandáta tua: * in æquitáte tua vivífica me."
+		]
+	},
+	{
+		"tags":["psalmus-cxviii-vi"],
+		"datum":[
+			"Et véniat super me misericórdia tua Dómine: * salutáre tuum secúndum elóquium tuum.",
+			"Et respondébo exprobrántibus mihi verbum: * quia sperávi in sermónibus tuis.",
+			"Et ne aúferas de ore meo verbum veritátis usquequáque: * quia in judíciis tuis supersperávi.",
+			"Et custódiam legem tuam semper: * in sǽculum et in sǽculum sǽculi.",
+			"Et ambulábam in latitúdine: * quia mandáta tua exquisívi.",
+			"Et loquébar in testimóniis tuis in conspéctu regum: * et non confundébar.",
+			"Et meditábar in mandátis tuis, * quæ diléxi.",
+			"Et levávi manus meas ad mandáta tua, quæ diléxi: * et exercébar in justificatiónibus tuis."
+		]
+	},
+	{
+		"tags":["psalmus-cxviii-vii"],
+		"datum":[
+			"Memor esto verbi tui servo tuo, * in quo mihi spem dedísti.",
+			"Hæc me consoláta est in humilitáte mea: * quia elóquium tuum vivificávit me.",
+			"Supérbi iníque agébant usquequáque: * a lege autem tua non declinávi.",
+			"Memor fui judiciórum tuórum a sǽculo Dómine: * et consolátus sum.",
+			"Deféctio ténuit me, * pro peccatóribus derelinquéntibus legem tuam.",
+			"Cantábiles mihi erant justificatiónes tuæ, * in loco peregrinatiónis meæ.",
+			"Memor fui nocte nóminis tui Dómine: * et custodívi legem tuam.",
+			"Hæc facta est mihi: * quia justificatiónes tuas exquisívi."
+		]
+	},
+	{
+		"tags":["psalmus-cxviii-viii"],
+		"datum":[
+			"Pórtio mea Dómine, * dixi custodíre legem tuam.",
+			"Deprecátus sum fáciem tuam in toto corde meo: * miserére mei secúndum elóquium tuum.",
+			"Cogitávi vias meas: * et convérti pedes meos in testimónia tua.",
+			"Parátus sum, et non sum turbátus: * ut custódiam mandáta tua.",
+			"Funes peccatórum circumpléxi sunt me: * et legem tuam non sum oblítus.",
+			"Média nocte surgébam ad confiténdum tibi, * super judícia justificatiónis tuæ.",
+			"Párticeps ego sum ómnium timéntium te: * et custodiéntium mandáta tua.",
+			"Misericórdia tua Dómine plena est terra: * justificatiónes tuas doce me."
+		]
+	},
+	{
+		"tags":["psalmus-cxviii-ix"],
+		"datum":[
+			"Bonitátem fecísti cum servo tuo Dómine, * secúndum verbum tuum.",
+			"Bonitátem, et disciplínam, et sciéntiam doce me: * quia mandátis tuis crédidi.",
+			"Priúsquam humiliárer ego delíqui: * proptérea elóquium tuum custodívi.",
+			"Bonus es tu: * et in bonitáte tua doce me justificatiónes tuas.",
+			"Multiplicáta est super me iníquitas superbórum: * ego autem in toto corde meo scrutábor mandáta tua.",
+			"Coagulátum est sicut lac cor eórum: * ego vero legem tuam meditátus sum.",
+			"Bonum mihi quia humiliásti me: * ut discam justificatiónes tuas.",
+			"Bonum mihi lex oris tui, * super míllia auri et argénti."
+		]
+	},
+	{
+		"tags":["psalmus-cxviii-x"],
+		"datum":[
+			"Manus tuæ fecérunt me, et plasmavérunt me: * da mihi intelléctum, et discam mandáta tua.",
+			"Qui timent te vidébunt me, et lætabúntur: * quia in verba tua supersperávi.",
+			"Cognóvi Dómine quia ǽquitas judícia tua: * et in veritáte tua humiliásti me.",
+			"Fiat misericórdia tua ut consolétur me, * secúndum elóquium tuum servo tuo.",
+			"Véniant mihi miseratiónes tuæ, et vivam: * quia lex tua meditátio mea est.",
+			"Confundántur supérbi, quia injúste iniquitátem fecérunt in me: * ego autem exercébor in mandátis tuis.",
+			"Convertántur mihi timéntes te: * et qui novérunt testimónia tua.",
+			"Fiat cor meum immaculátum in justificatiónibus tuis, * ut non confúndar."
+		]
+	},
+	{
+		"tags":["psalmus-cxviii-xi"],
+		"datum":[
+			"Defécit in salutáre tuum ánima mea: * et in verbum tuum supersperávi.",
+			"Defecérunt óculi mei in elóquium tuum, * dicéntes: Quando consoláberis me?",
+			"Quia factus sum sicut uter in pruína: * justificatiónes tuas non sum oblítus.",
+			"Quot sunt dies servi tui? * quando fácies de persequéntibus me judícium?",
+			"Narravérunt mihi iníqui fabulatiónes: * sed non ut lex tua.",
+			"Ómnia mandáta tua véritas: * iníque persecúti sunt me, ádjuva me.",
+			"Paulo minus consummavérunt me in terra: * ego autem non derelíqui mandáta tua.",
+			"Secúndum misericórdiam tuam vivífica me: * et custódiam testimónia oris tui."
+		]
+	},
+	{
+		"tags":["psalmus-cxviii-xii"],
+		"datum":[
+			"In ætérnum Dómine, * verbum tuum pérmanet in cœlo.",
+			"In generatiónem et generatiónem véritas tua: * fundásti terram, et pérmanet.",
+			"Ordinatióne tua persevérat dies: * quóniam ómnia sérviunt tibi.",
+			"Nisi quod lex tua meditátio mea est: * tunc forte periíssem in humilitáte mea.",
+			"In ætérnum non oblivíscar justificatiónes tuas: * quia in ipsis vivificásti me.",
+			"Tuus sum ego, salvum me fac: * quóniam justificatiónes tuas exquisívi.",
+			"Me exspectavérunt peccatóres ut pérderent me: * testimónia tua intelléxi.",
+			"Omnis consummatiónis vidi finem: * latum mandátum tuum nimis."
+		]
+	},
+	{
+		"tags":["psalmus-cxviii-xiii"],
+		"datum":[
+			"Quómodo diléxi legem tuam Dómine? * tota die meditátio mea est.",
+			"Super inimícos meos prudéntem me fecísti mandáto tuo: * quia in ætérnum mihi est.",
+			"Super omnes docéntes me intelléxi: * quia testimónia tua meditátio mea est.",
+			"Super senes intelléxi: * quia mandáta tua quæsívi.",
+			"Ab omni via mala prohíbui pedes meos: * ut custódiam verba tua.",
+			"A judíciis tuis non declinávi: * quia tu legem posuísti mihi.",
+			"Quam dúlcia faúcibus meis elóquia tua, * super mel ori meo!",
+			"A mandátis tuis intelléxi: * proptérea odívi omnem viam iniquitátis."
+		]
+	},
+	{
+		"tags":["psalmus-cxviii-xiv"],
+		"datum":[
+			"Lucérna pédibus meis verbum tuum, * et lumen sémitis meis.",
+			"Jurávi, et státui * custodíre judícia justítiæ tuæ.",
+			"Humiliátus sum usquequáque Dómine: * vivífica me secúndum verbum tuum.",
+			"Voluntária oris mei beneplácita fac Dómine: * et judícia tua doce me.",
+			"Ánima mea in mánibus meis semper: * et legem tuam non sum oblítus.",
+			"Posuérunt peccatóres láqueum mihi: * et de mandátis tuis non errávi.",
+			"Hæreditáte acquisívi testimónia tua in ætérnum: * quia exsultátio cordis mei sunt.",
+			"Inclinávi cor meum ad faciéndas justificatiónes tuas in ætérnum, * propter retributiónem."
+		]
+	},
+	{
+		"tags":["psalmus-cxviii-xv"],
+		"datum":[
+			"Iníquos ódio hábui: * et legem tuam diléxi.",
+			"Adjútor et suscéptor meus es tu: * et in verbum tuum supersperávi.",
+			"Declináte a me malígni: * et scrutábor mandáta Dei mei.",
+			"Súscipe me secúndum elóquium tuum, et vivam: * et non confúndas me ab exspectatióne mea.",
+			"Ádjuva me, et salvus ero: * et meditábor in justificatiónibus tuis semper.",
+			"Sprevísti omnes discedéntes a judíciis tuis: * quia injústa cogitátio eórum.",
+			"Prævaricántes reputávi omnes peccatóres terræ: * ídeo diléxi testimónia tua.",
+			"Confíge timóre tuo carnes meas: * a judíciis enim tuis tímui."
+		]
+	},
+	{
+		"tags":["psalmus-cxviii-xvi"],
+		"datum":[
+			"Feci judícium et justítiam: * non tradas me calumniántibus me.",
+			"Súscipe servum tuum in bonum: * non calumniéntur me supérbi.",
+			"Óculi mei defecérunt in salutáre tuum: * et in elóquium justítiæ tuæ.",
+			"Fac cum servo tuo secúndum misericórdiam tuam: * et justificatiónes tuas doce me.",
+			"Servus tuus sum ego: * da mihi intelléctum, ut sciam testimónia tua.",
+			"Tempus faciéndi Dómine: * dissipavérunt legem tuam.",
+			"Ídeo diléxi mandáta tua, * super aurum et topázion.",
+			"Proptérea ad ómnia mandáta tua dirigébar: * omnem viam iníquam ódio hábui."
+		]
+	},
+	{
+		"tags":["psalmus-cxviii-xvii"],
+		"datum":[
+			"Mirabília testimónia tua: * ídeo scrutáta est ea ánima mea.",
+			"Declarátio sermónum tuórum illúminat: * et intelléctum dat párvulis.",
+			"Os meum apérui, et attráxi spíritum: * quia mandáta tua desiderábam.",
+			"Áspice in me, et miserére mei, * secúndum judícium diligéntium nomen tuum.",
+			"Gressus meos dírige secúndum elóquium tuum: * et non dominétur mei omnis injustítia.",
+			"Rédime me a calúmniis hóminum: * ut custódiam mandáta tua.",
+			"Fáciem tuam illúmina super servum tuum: * et doce me justificatiónes tuas.",
+			"Éxitus aquárum deduxérunt óculi mei: * quia non custodiérunt legem tuam."
+		]
+	},
+	{
+		"tags":["psalmus-cxviii-xviii"],
+		"datum":[
+			"Justus es Dómine: * et rectum judícium tuum.",
+			"Mandásti justítiam testimónia tua: * et veritátem tuam nimis.",
+			"Tabéscere me fecit zelus meus: * quia oblíti sunt verba tua inimíci mei.",
+			"Ignítum elóquium tuum veheménter: * et servus tuus diléxit illud.",
+			"Adolescéntulus sum ego et contémptus: * justificatiónes tuas non sum oblítus.",
+			"Justítia tua, justítia in ætérnum: * et lex tua véritas.",
+			"Tribulátio, et angústia invenérunt me: * mandáta tua meditátio mea est.",
+			"Ǽquitas testimónia tua in ætérnum: * intelléctum da mihi, et vivam."
+		]
+	},
+	{
+		"tags":["psalmus-cxviii-xix"],
+		"datum":[
+			"Clamávi in toto corde meo, exaúdi me Dómine: * justificatiónes tuas requíram.",
+			"Clamávi ad te, salvum me fac: * ut custódiam mandáta tua.",
+			"Prævéni in maturitáte, et clamávi: * quia in verba tua supersperávi.",
+			"Prævenérunt óculi mei ad te dilúculo: * ut meditárer elóquia tua.",
+			"Vocem meam audi secúndum misericórdiam tuam Dómine: * et secúndum judícium tuum vivífica me.",
+			"Appropinquavérunt persequéntes me iniquitáti: * a lege autem tua longe facti sunt.",
+			"Prope es tu Dómine: * et omnes viæ tuæ véritas.",
+			"Inítio cognóvi de testimóniis tuis: * quia in ætérnum fundásti ea."
+		]
+	},
+	{
+		"tags":["psalmus-cxviii-xx"],
+		"datum":[
+			"Vide humilitátem meam, et éripe me: * quia legem tuam non sum oblítus.",
+			"Júdica judícium meum, et rédime me: * propter elóquium tuum vivífica me.",
+			"Longe a peccatóribus salus: * quia justificatiónes tuas non exquisiérunt.",
+			"Misericórdiæ tuæ multæ Dómine: * secúndum judícium tuum vivífica me.",
+			"Multi qui persequúntur me, et tríbulant me: * a testimóniis tuis non declinávi.",
+			"Vidi prævaricántes, et tabescébam: * quia elóquia tua non custodíerunt.",
+			"Vide quóniam mandáta tua diléxi Dómine: * in misericórdia tua vivífica me.",
+			"Princípium verbórum tuórum, véritas: * in ætérnum ómnia judícia justítiæ tuæ."
+		]
+	},
+	{
+		"tags":["psalmus-cxviii-xxi"],
+		"datum":[
+			"Príncipes persecúti sunt me gratis: * et a verbis tuis formidávit cor meum.",
+			"Lætábor ego super elóquia tua: * sicut qui invénit spólia multa.",
+			"Iniquitátem ódio hábui, et abominátus sum: * legem autem tuam diléxi.",
+			"Sépties in die laudem dixi tibi, * super judícia justítiæ tuæ.",
+			"Pax multa diligéntibus legem tuam: * et non est illis scándalum.",
+			"Exspectábam salutáre tuum Dómine: * et mandáta tua diléxi.",
+			"Custodívit ánima mea testimónia tua: * et diléxit ea veheménter.",
+			"Servávi mandáta tua, et testimónia tua: * quia omnes viæ meæ in conspéctu tuo."
+		]
+	},
+	{
+		"tags":["psalmus-cxviii-xxii"],
+		"datum":[
+			"Appropínquet deprecátio mea in conspéctu tuo Dómine: * juxta elóquium tuum da mihi intelléctum.",
+			"Intret postulátio mea in conspéctu tuo: * secúndum elóquium tuum éripe me.",
+			"Eructábunt lábia mea hymnum, * cum docúeris me justificatiónes tuas.",
+			"Pronuntiábit lingua mea elóquium tuum: * quia ómnia mandáta tua ǽquitas.",
+			"Fiat manus tua ut salvet me: * quóniam mandáta tua elégi.",
+			"Concupívi salutáre tuum Dómine: * et lex tua meditátio mea est.",
+			"Vivet ánima mea, et laudábit te: * et judícia tua adjuvábunt me.",
+			"Errávi, sicut ovis, quæ périit: * quære servum tuum, quia mandáta tua non sum oblítus."
+		]
+	},
+	{
+		"tags":["psalmus-cxviii"],
+		"datum":[
+			["psalmus-cxviii-i"],["psalmus-cxviii-ii"],["psalmus-cxviii-iii"],["psalmus-cxviii-iv"],["psalmus-cxviii-v"],["psalmus-cxviii-vi"],["psalmus-cxviii-vii"],["psalmus-cxviii-viii"],["psalmus-cxviii-ix"],["psalmus-cxviii-x"],["psalmus-cxviii-xi"],["psalmus-cxviii-xii"],["psalmus-cxviii-xiii"],["psalmus-cxviii-xiv"],["psalmus-cxviii-xv"],["psalmus-cxviii-xvi"],["psalmus-cxviii-xvii"],["psalmus-cxviii-xviii"],["psalmus-cxviii-xix"],["psalmus-cxviii-xx"],["psalmus-cxviii-xxi"],["psalmus-cxviii-xxii"]
+		]
+	},
 	{"tags":["psalmus-cxix"],
 	"datum":[
-		"PASTA"
+		"Ad Dóminum cum tribulárer clamávi: * et exaudívit me.",
+		"Dómine líbera ánimam meam a lábiis iníquis, * et a lingua dolósa.",
+		"Quid detur tibi, aut quid apponátur tibi * ad linguam dolósam?",
+		"Sagíttæ poténtis acútæ, * cum carbónibus desolatóriis.",
+		"Heu mihi, quia incolátus meus prolongátus est: habitávi cum habitántibus Cedar: * multum íncola fuit ánima mea.",
+		"Cum his, qui odérunt pacem, eram pacíficus: * cum loquébar illis, impugnábant me gratis."
 	]},
 	{"tags":["psalmus-cxx"],
 	"datum":[
@@ -2308,7 +2762,15 @@
 	]},
 	{"tags":["psalmus-cxxi"],
 	"datum":[
-		"PASTA"
+		"Lætátus sum in his, quæ dicta sunt mihi: * in domum Dómini íbimus.",
+		"Stantes erant pedes nostri, * in átriis tuis Jerúsalem.",
+		"Jerúsalem, quæ ædificátur ut cívitas: * cujus participátio ejus in idípsum.",
+		"Illuc enim ascendérunt tribus, tribus Dómini: * testimónium Israël ad confiténdum nómini Dómini.",
+		"Quia illic sedérunt sedes in judício, * sedes super domum David.",
+		"Rogáte quæ ad pacem sunt Jerúsalem: * et abundántia diligéntibus te:",
+		"Fiat pax in virtúte tua: * et abundántia in túrribus tuis.",
+		"Propter fratres meos, et próximos meos, * loquébar pacem de te:",
+		"Propter domum Dómini Dei nostri, * quæsívi bona tibi."
 	]},
 	{"tags":["psalmus-cxxii"],
 	"datum":[
@@ -2350,7 +2812,12 @@
 	]},
 	{"tags":["psalmus-cxxvi"],
 	"datum":[
-		"PASTA"
+		"Nisi Dóminus ædificáverit domum, * in vanum laboravérunt qui ædíficant eam.",
+		"Nisi Dóminus custodíerit civitátem, * frustra vígilat qui custódit eam.",
+		"Vanum est vobis ante lucem súrgere: * súrgite postquam sedéritis, qui manducátis panem dolóris.",
+		"Cum déderit diléctis suis somnum: * ecce hæréditas Dómini fílii, merces fructus ventris.",
+		"Sicut sagíttæ in manu poténtis: * ita fílii excussórum.",
+		"Beátus vir qui implévit desidérium suum ex ipsis: * non confundétur cum loquétur inimícis suis in porta."
 	]},
 	{"tags":["psalmus-cxxvii"],
 	"datum":[
@@ -2422,7 +2889,10 @@
 	]},
 	{"tags":["psalmus-cxxxiii"],
 	"datum":[
-		"PASTA"
+		"Ecce nunc benedícite Dóminum, * omnes servi Dómini:",
+		"Qui statis in domo Dómini, * in átriis domus Dei nostri,",
+		"In nóctibus extóllite manus vestras in sancta, * et benedícite Dóminum.",
+		"Benedícat te Dóminus ex Sion, * qui fecit cœlum et terram."
 	]},
 	{"tags":["psalmus-cxxxiv"],
 	"datum":[
@@ -2665,20 +3135,61 @@
 		"Non in fortitúdine equi voluntátem habébit: * nec in tíbiis viri beneplácitum erit ei.",
 		"Beneplácitum est Dómino super timéntes eum: * et in eis, qui sperant super misericórdia ejus."
 	]},
-	{"tags":["psalmus-cxlvii"],
-	"datum":[
-		"PASTA"
-	]},
-	{"tags":["psalmus-cxlviii"],
-	"datum":[
-		"PASTA"
-	]},
-	{"tags":["psalmus-cxlix"],
-	"datum":[
-		"PASTA"
-	]},
-	{"tags":["psalmus-cl"],
-	"datum":[
-		"PASTA"
-	]}
+	{
+		"tags":["psalmus-cxlvii"],
+		"datum":[
+			"Lauda Jerúsalem Dóminum: * lauda Deum tuum Sion.",
+			"Quóniam confortávit seras portárum tuárum: * benedíxit fíliis tuis in te.",
+			"Qui pósuit fines tuos pacem: * et ádipe fruménti sátiat te.",
+			"Qui emíttit elóquium suum terræ: * velóciter currit sermo ejus.",
+			"Qui dat nivem sicut lanam: * nébulam sicut cínerem spargit.",
+			"Mittit crystállum suam sicut buccéllas: * ante fáciem frígoris ejus quis sustinébit?",
+			"Emíttet verbum suum, et liquefáciet ea: * flabit spíritus ejus, et fluent aquæ.",
+			"Qui annúntiat verbum suum Jacob: * justítias, et judícia sua Israël.",
+			"Non fecit táliter omni natióni: * et judícia sua non manifestávit eis."
+		]
+	},
+	{
+		"tags":["psalmus-cxlviii"],
+		"datum":[
+			"Laudáte Dóminum de cœlis: * laudáte eum in excélsis.",
+			"Laudáte eum omnes Ángeli ejus: * laudáte eum omnes virtútes ejus.",
+			"Laudáte eum sol et luna: * laudáte eum omnes stellæ, et lumen.",
+			"Laudáte eum cœli cœlórum: * et aquæ omnes, quæ super cœlos sunt, laudent nomen Dómini.",
+			"Quia ipse dixit, et facta sunt: * ipse mandávit, et creáta sunt.",
+			"Státuit ea in ætérnum, et in sǽculum sǽculi: * præcéptum pósuit, et non præteríbit.",
+			"Laudáte Dóminum de terra, * dracónes, et omnes abýssi.",
+			"Ignis, grando, nix, glácies, spíritus procellárum: * quæ fáciunt verbum ejus:",
+			"Montes, et omnes colles: * ligna fructífera, et omnes cedri.",
+			"Béstiæ, et univérsa pécora: * serpéntes, et vólucres pennátæ:",
+			"Reges terræ, et omnes pópuli: * príncipes, et omnes júdices terræ.",
+			"Júvenes, et vírgines: + senes cum junióribus laudent nomen Dómini: * quia exaltátum est nomen ejus solíus.",
+			"Conféssio ejus super cœlum, et terram: * et exaltávit cornu pópuli sui.",
+			"Hymnus ómnibus sanctis ejus: * fíliis Israël, pópulo appropinquánti sibi."
+		]
+	},
+	{
+		"tags":["psalmus-cxlix"],
+		"datum":[
+			"Cantáte Dómino cánticum novum: * laus ejus in ecclésia sanctórum.",
+			"Lætétur Israël in eo, qui fecit eum: * et fílii Sion exsúltent in rege suo.",
+			"Laudent nomen ejus in choro: * in týmpano, et psaltério psallant ei.",
+			"Quia beneplácitum est Dómino in pópulo suo: * et exaltábit mansuétos in salútem.",
+			"Exsultábunt sancti in glória: * lætabúntur in cubílibus suis.",
+			"Exaltatiónes Dei in gútture eórum: * et gládii ancípites in mánibus eórum:",
+			"Ad faciéndam vindíctam in natiónibus: * increpatiónes in pópulis.",
+			"Ad alligándos reges eórum in compédibus: * et nóbiles eórum in mánicis férreis.",
+			"Ut fáciant in eis judícium conscríptum: * glória hæc est ómnibus sanctis ejus."
+		]
+	},
+	{
+		"tags":["psalmus-cl"],
+		"datum":[
+			"Laudáte Dóminum in sanctis ejus: * laudáte eum in firmaménto virtútis ejus.",
+			"Laudáte eum in virtútibus ejus: * laudáte eum secúndum multitúdinem magnitúdinis ejus.",
+			"Laudáte eum in sono tubæ: * laudáte eum in psaltério, et cíthara.",
+			"Laudáte eum in týmpano, et choro: * laudáte eum in chordis, et órgano.",
+			"Laudáte eum in cýmbalis benesonántibus: + laudáte eum in cýmbalis jubilatiónis: * omnis spíritus laudet Dóminum."
+		]
+	}
 ]


### PR DESCRIPTION
Updated psalms to use 1962 as base, incorporated previous proofing work
To be proofed:
{6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 43, 44, 45, 46, 47, 48, 49, 51, 52, 54, 55, 56, 57, 58, 59, 60, 61, 63, 64, 65, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 91, 93, 94, 95, 96, 97, 98, 100, 101, 102, 103, 104, 105, 106, 107, 108, 113, 114, 115, 116, 117, 120, 122, 123, 124, 125, 127, 128, 129, 130, 131, 132, 134, 135, 136, 137, 138, 139, 140, 141, 142, 143, 144, 145, 146}
vi, vii, viii, ix, x, xi, xii, xiii, xiv, xv, xvi, xvii, xviii, xix, xx, xxi, xxii, xxiii, xxiv, xxv, xxvi, xxvii, xxviii, xxix, xxxi, xxxii, xxxiii, xxxiv, xxxv, xxxvi, xxxvii, xxxviii, xxxix, xl, xli, xliii, xliv, xlv, xlvi, xlvii, xlviii, xlix, li, lii, liv, lv, lvi, lvii, lviii, lix, lx, lxi, lxiii, lxiv, lxv, lxvii, lxviii, lxix, lxx, lxxi, lxxii, lxxiii, lxxiv, lxxv, lxxvi, lxxvii, lxxviii, lxxix, lxxx, lxxxi, lxxxii, lxxxiii, lxxxiv, lxxxv, lxxxvi, lxxxvii, lxxxviii, lxxxix, xci, xciii, xciv, xcv, xcvi, xcvii, xcviii, c, ci, cii, ciii, civ, cv, cvi, cvii, cviii, cxiii, cxiv, cxv, cxvi, cxvii, cxx, cxxii, cxxiii, cxxiv, cxxv, cxxvii, cxxviii, cxxix, cxxx, cxxxi, cxxxii, cxxxiv, cxxxv, cxxxvi, cxxxvii, cxxxviii, cxxxix, cxl, cxli, cxlii, cxliii, cxliv, cxlv, cxlvi

Main differences so far seen between 1888 and 1962 psalms: very occasionally punctuation differences, some differences in chant notation (EX in Ps 30 in lines with the † in the 1962; for those differences, I left the dagger in so we can find the occurrences easily to figure out what to do with them) 

#Breviarium Romanum Pars Verna
#PDF pg 29 = Breviary pg 1, 1pg to 1 pg; PDF pg 573 = Breviary pg [1]
#pg 980-981 ([409-410] of the official numbering) of Verna has a psalms index, following pages have canticles index
#Add 28 to the Breviary pg number to get the PDF pg to go to