### PR TITLE
Proof psalmi.json: Gradual Psalms

### DIFF
--- a/breviarium/psalmi.json
+++ b/breviarium/psalmi.json
@@ -2752,9 +2752,9 @@
 	{"tags":["psalmus-cxx"],
 	"datum":[
 		"Levávi óculos meos in montes, * unde véniet auxílium mihi.",
-		"Auxílium meum a Dómino, * qui fecit cælum et terram.",
+		"Auxílium meum a Dómino, * qui fecit cœlum et terram.",
 		"Non det in commotiónem pedem tuum: * neque dormítet qui custódit te.",
-		"Ecce, non dormitábit neque dórmiet, * qui custódit Israël.",
+		"Ecce non dormitábit neque dórmiet, * qui custódit Israël.",
 		"Dóminus custódit te, Dóminus protéctio tua, * super manum déxteram tuam.",
 		"Per diem sol non uret te: * neque luna per noctem.",
 		"Dóminus custódit te ab omni malo: * custódiat ánimam tuam Dóminus.",
@@ -2774,10 +2774,10 @@
 	]},
 	{"tags":["psalmus-cxxii"],
 	"datum":[
-		"Ad te levávi óculos meos, * qui hábitas in cælis.",
-		"Ecce sicut óculi servórum, * in mánibus dominórum suórum.",
-		"Sicut óculi ancíllæ in mánibus dóminæ suæ : * ita óculi nostri ad Dóminum, Deum nostrum, donec misereátur nostri.",
-		"Miserére nostri, Dómine, miserére nostri: * quia multum repléti sumus despectióne:",
+		"Ad te levávi óculos meos, * qui hábitas in cœlis.",
+		"Ecce sicut óculi servórum, * in mánibus dominórum suórum,",
+		"Sicut óculi ancíllæ in mánibus dóminæ suæ: * ita óculi nostri ad Dóminum Deum nostrum donec misereátur nostri.",
+		"Miserére nostri Dómine, miserére nostri: * quia multum repléti sumus despectióne:",
 		"Quia multum repléta est ánima nostra: * oppróbrium abundántibus, et despéctio supérbis."
 	]},
 	{"tags":["psalmus-cxxiii"],
@@ -2787,25 +2787,25 @@
 		"Cum irascerétur furor eórum in nos, * fórsitan aqua absorbuísset nos.",
 		"Torréntem pertransívit ánima nostra: * fórsitan pertransísset ánima nostra aquam intolerábilem.",
 		"Benedíctus Dóminus * qui non dedit nos, in captiónem déntibus eórum.",
-		"Anima nostra sicut passer erépta est * de láqueo venántium.",
+		"Anima nostra sicut passer erépta est * de láqueo venántium:",
 		"Láqueus contrítus est, * et nos liberáti sumus.",
-		"Adjutórium nostrum in nómine Dómini, * qui fecit cælum et terram."
+		"Adjutórium nostrum in nómine Dómini, * qui fecit cœlum et terram."
 	]},
 	{"tags":["psalmus-cxxiv"],
 	"datum":[
 		"Qui confídunt in Dómino, sicut mons Sion: * non commovébitur in ætérnum, qui hábitat in Jerúsalem.",
-		"Montes in circúitu ejus: † et Dóminus in circúitu pópuli sui, * ex hoc nunc et usque in sǽculum.",
+		"Montes in circúitu ejus: † et Dóminus in circúitu pópuli sui, ex hoc nunc et usque in sǽculum.",
 		"Quia non relínquet Dóminus virgam peccatórum super sortem justórum: * ut non exténdant justi ad iniquitátem manus suas.",
-		"Bénefac, Dómine, bonis, * et rectis corde.",
+		"Bénefac Dómine bonis, * et rectis corde.",
 		"Declinántes autem in obligatiónes addúcet Dóminus cum operántibus iniquitátem: * pax super Israël."
 	]},
 	{"tags":["psalmus-cxxv"],
 	"datum":[
 		"In converténdo Dóminus captivitátem Sion: * facti sumus sicut consoláti:",
-		"Tunc replétum est gáudio os nostrum: * et lingua nostra exsultatióne.",
+		"Tunc replétum est gaúdio os nostrum: * et lingua nostra exsultatióne.",
 		"Tunc dicent inter Gentes: * Magnificávit Dóminus fácere cum eis.",
 		"Magnificávit Dóminus fácere nobíscum: * facti sumus lætántes.",
-		"Convérte, Dómine, captivitátem nostram, * sicut torrens in austro.",
+		"Convérte Dómine captivitátem nostram, * sicut torrens in Austro.",
 		"Qui séminant in lácrimis, * in exsultatióne metent.",
 		"Eúntes ibant et flebant, * mitténtes sémina sua.",
 		"Veniéntes autem vénient cum exsultatióne, * portántes manípulos suos."
@@ -2815,7 +2815,7 @@
 		"Nisi Dóminus ædificáverit domum, * in vanum laboravérunt qui ædíficant eam.",
 		"Nisi Dóminus custodíerit civitátem, * frustra vígilat qui custódit eam.",
 		"Vanum est vobis ante lucem súrgere: * súrgite postquam sedéritis, qui manducátis panem dolóris.",
-		"Cum déderit diléctis suis somnum: * ecce hæréditas Dómini fílii, merces fructus ventris.",
+		"Cum déderit diléctis suis somnum: * ecce hæréditas Dómini fílii: merces, fructus ventris.",
 		"Sicut sagíttæ in manu poténtis: * ita fílii excussórum.",
 		"Beátus vir qui implévit desidérium suum ex ipsis: * non confundétur cum loquétur inimícis suis in porta."
 	]},
@@ -2823,32 +2823,32 @@
 	"datum":[
 		"Beáti omnes, qui timent Dóminum, * qui ámbulant in viis ejus.",
 		"Labóres mánuum tuárum quia manducábis: * beátus es, et bene tibi erit.",
-		"Uxor tua sicut vitis abúndans: * in latéribus domus tuæ.",
-		"Fílii tui sicut novéllæ olivárum: * in circúitu mensæ tuæ.",
+		"Uxor tua sicut vitis abúndans, * in latéribus domus tuæ.",
+		"Fílii tui sicut novéllæ olivárum, * in circúitu mensæ tuæ.",
 		"Ecce sic benedicétur homo, * qui timet Dóminum.",
 		"Benedícat tibi Dóminus ex Sion: * et vídeas bona Jerúsalem ómnibus diébus vitæ tuæ.",
-		"Et vídeas fílios filiórum tuórum: * pacem super Israël."
+		"Et vídeas fílios filiórum tuórum, * pacem super Israël."
 	]},
 	{"tags":["psalmus-cxxviii"],
 	"datum":[
-		"Sæpe expugnavérunt me a juventúte mea, * dicat nunc Israël:",
+		"Sæpe expugnavérunt me a juventúte mea, * dicat nunc Israël.",
 		"Sæpe expugnavérunt me a juventúte mea: * étenim non potuérunt mihi.",
 		"Supra dorsum meum fabricavérunt peccatóres: * prolongavérunt iniquitátem suam.",
 		"Dóminus justus concídit cervíces peccatórum: * confundántur et convertántur retrórsum omnes, qui odérunt Sion.",
-		"Fiant sicut fœnum tectórum: * quod priúsquam evellátur exáruit:",
-		"De quo non implévit manum suam qui metit: * et sinum suum qui manípulos cólligit.",
+		"Fiant sicut fœnum tectórum: * quod priúsquam evellátur, exáruit:",
+		"De quo non implévit manum suam qui metit, * et sinum suum qui manípulos cólligit.",
 		"Et non dixérunt qui præteríbant: Benedíctio Dómini super vos: * benedíximus vobis in nómine Dómini."
 	]},
 	{"tags":["psalmus-cxxix"],
 	"datum":[
-		"De profúndis clamávi ad te, Dómine: * Dómine, exáudi vocem meam :",
-		"Fiant aures tuæ intendéntes: * in vocem deprecatiónis meæ.",
-		"Si iniquitátes observáveris, Dómine: * Dómine, quis sustinébit?",
-		"Quia apud te propitiátio est: * et propter legem tuam sustínui te, Dómine.",
+		"De profúndis clamávi ad te Dómine: * Dómine exaúdi vocem meam:",
+		"Fiant aures tuæ intendéntes, * in vocem deprecatiónis meæ.",
+		"Si iniquitátes observáveris Dómine: * Dómine quis sustinébit?",
+		"Quia apud te propitiátio est: * et propter legem tuam sustínui te Dómine.",
 		"Sustínuit ánima mea in verbo ejus: * sperávit ánima mea in Dómino.",
 		"A custódia matutína usque ad noctem: * speret Israël in Dómino.",
 		"Quia apud Dóminum misericórdia: * et copiósa apud eum redémptio.",
-		"Et ipse rédimet Israël: * ex ómnibus iniquitátibus ejus."
+		"Et ipse rédimet Israël, * ex ómnibus iniquitátibus ejus."
 	]},
 	{"tags":["psalmus-cxxx"],
 	"datum":[


### PR DESCRIPTION
Proofed psalms 120 - 129
I made an executive decision to interpret words using ñ in the source breviary (for example, Dñm in psalm 127) as a pure abbreviation and to render it in psalmi.json as the (Dómini)

For additional clarity, the way I have decided to deal with the differences between 1962 and 1888 chant structure until you render a verdict on that is to use the chant structure found in the source breviary for the line but to replace the first asterisk with a dagger so that we can easily ctrl-f it later; I haven't yet found any daggers in the source breviary 

Additionally, for convenience, copy-pasting diacritic alt codes that I know á	0225	Á	0193
é	0233	É	0201
í	0237	Í	0205
ó	0243	Ó	0211
ú	0250	Ú	0218
ý	0253	Ý	0221
æ	0230	Æ	0198
ǽ	xxxx	Ǽ	xxxx
œ	0156	Œ	0140
ë	0235	Ë	0203
ñ	0241